### PR TITLE
fixed for mssql and pg

### DIFF
--- a/app/models/wbs_query.rb
+++ b/app/models/wbs_query.rb
@@ -31,8 +31,7 @@ class WbsQuery
       .select(:id)
       .visible
       .where(project_id: @project.id)
-      .joins("INNER JOIN (#{subquery.to_sql}) parent")
-      .where("#{Issue.table_name}.root_id = parent.root_id")
+      .joins("INNER JOIN (#{subquery.to_sql}) parent on #{Issue.table_name}.root_id = parent.root_id")
       .where("#{Issue.table_name}.lft >= parent.lft")
       .where("#{Issue.table_name}.rgt <= parent.rgt")
   end
@@ -42,7 +41,7 @@ class WbsQuery
   def excluded_trackers
     Tracker.select(:id)
       .where(
-        "#{Tracker.table_name}.id IN (?) OR #{Tracker.table_name}.fields_bits & ?",
+        "#{Tracker.table_name}.id IN (?) OR (#{Tracker.table_name}.fields_bits & ?) != 0",
         RedmineWbs.excluded_tracker_ids,
         RedmineWbs.required_core_field_bits
       )


### PR DESCRIPTION
# Description

mssql and pg force a boolean expression for OR, hence ()!=0 on line 44
mssql and pg need a join expression, moved previous line 35 into 34

Fixes #37

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] on test system with pg and mssql

**Test Configuration**:
* Redmine version: 4.2.1
* Toolchain: ruby 2.7

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code